### PR TITLE
Implement permissions for commenting on tasks

### DIFF
--- a/ElastosBountyProgram/back-end/src/service/CommentService.ts
+++ b/ElastosBountyProgram/back-end/src/service/CommentService.ts
@@ -15,6 +15,14 @@ export default class extends Base {
             .populate('createdBy')
 
         if (commentable) {
+            if (type === 'Task') {
+                if (_.includes([ constant.TASK_STATUS.CREATED, constant.TASK_STATUS.PENDING ], commentable.status) &&
+                    commentable.createdBy._id !== createdBy.current_user_id &&
+                    !createdBy.is_admin) {
+                    throw 'not allowed to post on this task'
+                }
+            }
+
             const updateObj = {
                 comments: commentable.comments || []
             }

--- a/ElastosBountyProgram/front-end/src/module/task/detail/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/task/detail/Component.js
@@ -48,7 +48,7 @@ export default class extends BaseComponent {
 
     ord_render () {
 
-        const isTaskOwner = this.props.task.createdBy._id === this.props.userId
+        const isTaskOwner = this.isTaskOwner()
 
         return (
             <div className="public">
@@ -214,7 +214,7 @@ export default class extends BaseComponent {
                             </Row>
                         </div>}
 
-                        <Comments type="task" canPost={true} model={this.props.task}/>
+                        <Comments type="task" canPost={this.canPost()} model={this.props.task}/>
                     </Col>
                     <Col span={6} className="gridCol applicants">
                         <h4>{this.state.isDeveloperEvent ? 'Registrants' : 'Applicants'}</h4>
@@ -517,4 +517,14 @@ export default class extends BaseComponent {
     }
     // TODO: after max applicants are selected, we should send an email to those
     // that were not selected
+
+    canPost = () => {
+        return !_.includes([ TASK_STATUS.CREATED, TASK_STATUS.PENDING ], this.props.task.status) ||
+            this.isTaskOwner() ||
+            this.props.is_admin
+    }
+
+    isTaskOwner = () => {
+        return this.props.task.createdBy._id === this.props.userId
+    }
 }

--- a/ElastosBountyProgram/front-end/src/module/task/detail/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/task/detail/Container.js
@@ -7,6 +7,7 @@ import { message } from 'antd/lib/index'
 export default createContainer(Component, (state) => {
     return {
         userId: state.user.current_user_id,
+        is_admin: state.user.is_admin,
         is_login: state.user.is_login
     }
 }, () => {


### PR DESCRIPTION
Not allowing posting on tasks that are CREATED or PENDING unless one is an admin or a task owner.

Lets keep this one open as a starter for more robust permission handling.