### PR TITLE
Fix: Profile/Tasks Active Tasks divider doesnt go full width

### DIFF
--- a/ElastosBountyProgram/front-end/src/module/page/profile/tasks/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/profile/tasks/Component.js
@@ -156,7 +156,7 @@ export default class extends StandardPage {
                                     </div>
                                     }
 
-                                    <Divider className="clearfix">Active Tasks</Divider>
+                                    <Divider>Active Tasks</Divider>
 
                                     <Table
                                         columns={columns}


### PR DESCRIPTION
Divider cannot have .clearfix, as .clearfix:after has visibility:hidden, which causes a collision.