### PR TITLE
Fix: Show loading states in lists

### DIFF
--- a/ElastosBountyProgram/front-end/src/module/page/admin/forms/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/admin/forms/Container.js
@@ -9,8 +9,6 @@ export default createContainer(Component, (state) => {
 
     let submissionState = state.submission
 
-    submissionState.loading = false
-
     if (!_.isArray(state.submission.all_submissions)) {
         submissionState.all_submissions = _.values(state.submission.all_submissions)
     }

--- a/ElastosBountyProgram/front-end/src/module/page/admin/submissions/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/admin/submissions/Container.js
@@ -7,8 +7,6 @@ export default createContainer(Component, (state) => {
 
     let submissionState = state.submission
 
-    submissionState.loading = false
-
     if (!_.isArray(state.submission.all_submissions)) {
         submissionState.all_submissions = _.values(state.submission.all_submissions)
     }

--- a/ElastosBountyProgram/front-end/src/module/page/admin/tasks/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/admin/tasks/Container.js
@@ -9,8 +9,6 @@ export default createContainer(Component, (state) => {
 
     let taskState = state.task
 
-    taskState.loading = false
-
     if (!_.isArray(state.task.all_tasks)) {
         taskState.all_tasks = _.values(state.task.all_tasks)
     }

--- a/ElastosBountyProgram/front-end/src/module/page/profile/tasks/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/profile/tasks/Container.js
@@ -13,7 +13,6 @@ export default createContainer(Component, (state) => {
     const taskState = {
         ...state.task,
         currentUserId,
-        loading: false,
         is_leader: state.user.role === USER_ROLE.LEADER,
         is_admin: state.user.role === USER_ROLE.ADMIN
     }


### PR DESCRIPTION
Respect the loading state in (task/submission/form) lists. It takes the first object's loading state for lists, which could be improved, but in most cases it works fine.