### PR TITLE
Fix: Redux key updates are not scoped per redux type

### DIFF
--- a/ElastosBountyProgram/front-end/src/model/BaseRedux.js
+++ b/ElastosBountyProgram/front-end/src/model/BaseRedux.js
@@ -10,6 +10,15 @@ export default class {
         this.buildActions();
     }
 
+    getPathName() {
+        const userDefineTypes = this.defineTypes()
+        if(!_.isArray(userDefineTypes) || !_.isString(userDefineTypes[0])){
+            throw new Error('invalid redux types definition : '+userDefineTypes)
+        }
+
+        return userDefineTypes[0]
+    }
+
     buildTypes(){
         const userDefineTypes = this.defineTypes();
         if(!_.isArray(userDefineTypes) || !_.isString(userDefineTypes[0])){
@@ -32,7 +41,10 @@ export default class {
             this.actions[update_key] = (param)=>{
                 return {
                     type: update_key,
-                    param
+                    param: {
+                        key: param,
+                        pathname: pathName
+                    }
                 }
             };
 
@@ -57,11 +69,14 @@ export default class {
     }
 
     buildReducer(){
+        const pathName = this.getPathName()
         _.extend(this.reducers, this.defineReducers());
         return (state=this.defineDefaultState(), action)=>{
             const type = action.type;
-            if(this.types[type] && this.reducers[type]){
-                return this.reducers[type](state, action.param);
+            if (!action.param || action.param.pathname === pathName) {
+                if(this.types[type] && this.reducers[type]){
+                    return this.reducers[type](state, _.has(action.param, 'key') ? action.param.key : action.param)
+                }
             }
 
             return state;

--- a/ElastosBountyProgram/front-end/src/module/page/admin/forms/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/admin/forms/Container.js
@@ -9,8 +9,6 @@ export default createContainer(Component, (state) => {
 
     let submissionState = state.submission
 
-    submissionState.loading = false
-
     if (!_.isArray(state.submission.all_submissions)) {
         submissionState.all_submissions = _.values(state.submission.all_submissions)
     }

--- a/ElastosBountyProgram/front-end/src/module/page/admin/submissions/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/admin/submissions/Container.js
@@ -7,8 +7,6 @@ export default createContainer(Component, (state) => {
 
     let submissionState = state.submission
 
-    submissionState.loading = false
-
     if (!_.isArray(state.submission.all_submissions)) {
         submissionState.all_submissions = _.values(state.submission.all_submissions)
     }

--- a/ElastosBountyProgram/front-end/src/module/page/admin/tasks/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/admin/tasks/Container.js
@@ -9,8 +9,6 @@ export default createContainer(Component, (state) => {
 
     let taskState = state.task
 
-    taskState.loading = false
-
     if (!_.isArray(state.task.all_tasks)) {
         taskState.all_tasks = _.values(state.task.all_tasks)
     }

--- a/ElastosBountyProgram/front-end/src/module/page/profile/tasks/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/profile/tasks/Container.js
@@ -13,7 +13,6 @@ export default createContainer(Component, (state) => {
     const taskState = {
         ...state.task,
         currentUserId,
-        loading: false,
         is_leader: state.user.role === USER_ROLE.LEADER,
         is_admin: state.user.role === USER_ROLE.ADMIN
     }

--- a/ElastosBountyProgram/front-end/src/module/page/social/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Component.js
@@ -172,7 +172,7 @@ export default class extends StandardPage {
                                 columns={columns}
                                 rowKey={(item) => item._id}
                                 dataSource={eventData}
-                                loading={this.props.loading}
+                                loading={this.props.task_loading}
                             />
                         </Col>
                         {/*
@@ -199,6 +199,7 @@ export default class extends StandardPage {
                             <List
                                 size="small"
                                 dataSource={this.props.myCommunities}
+                                loading={this.props.loading}
                                 renderItem={(community) => {
                                     return <List.Item>
                                         <a onClick={this.filterByMyCommunity.bind(this, community)}>
@@ -233,7 +234,7 @@ export default class extends StandardPage {
                                 columns={columns}
                                 rowKey={(item) => item._id}
                                 dataSource={availTasksData}
-                                loading={this.props.loading}
+                                loading={this.props.task_loading}
                             />
                         </Col>
                         <Col md={{span:24}} lg={{span: 8}} className="d_rightContainer d_box">

--- a/ElastosBountyProgram/front-end/src/module/page/social/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Container.js
@@ -69,8 +69,6 @@ export default createContainer(Component, (state) => {
     taskState.community_loading = state.community.loading
     taskState.user_loading = state.user.loading
 
-    console.log('page/social::Container loading changed to ', taskState.loading, ' (task ', state.task.loading, ' comm ', state.community.loading, ' user ', state.user.loading, ' )')
-
     return taskState
 
 }, () => {

--- a/ElastosBountyProgram/front-end/src/module/page/social/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Container.js
@@ -63,6 +63,14 @@ export default createContainer(Component, (state) => {
         taskState.myCommunities = _.values(state.community.my_communities)
     }
 
+    taskState.loading = state.task.loading || state.community.loading || state.user.loading
+
+    taskState.task_loading = state.task.loading
+    taskState.community_loading = state.community.loading
+    taskState.user_loading = state.user.loading
+
+    console.log('page/social::Container loading changed to ', taskState.loading, ' (task ', state.task.loading, ' comm ', state.community.loading, ' user ', state.user.loading, ' )')
+
     return taskState
 
 }, () => {

--- a/ElastosBountyProgram/front-end/src/service/TaskService.js
+++ b/ElastosBountyProgram/front-end/src/service/TaskService.js
@@ -6,7 +6,7 @@ import {TASK_CANDIDATE_STATUS, TASK_STATUS} from '@/constant'
 
 export default class extends BaseService {
 
-    async list(filter={}){
+    async list(filter = {}) {
         const result = await api_request({
             path: '/api/task/list',
             method: 'get',

--- a/ElastosBountyProgram/front-end/src/service/TeamService.js
+++ b/ElastosBountyProgram/front-end/src/service/TeamService.js
@@ -18,6 +18,7 @@ export default class extends BaseService {
 
         const userRedux = this.store.getRedux('user')
 
+        this.dispatch(userRedux.actions.loading_update(true))
         const result = await api_request({
             path: '/api/team/list',
             method: 'get',
@@ -26,6 +27,7 @@ export default class extends BaseService {
             }
         });
 
+        this.dispatch(userRedux.actions.loading_update(false))
         this.dispatch(userRedux.actions.teams_update(result.list))
 
         return result

--- a/ElastosBountyProgram/front-end/src/store/redux/community.js
+++ b/ElastosBountyProgram/front-end/src/store/redux/community.js
@@ -7,7 +7,7 @@ class CommunityRedux extends BaseRedux {
 
     defineDefaultState(){
         return {
-            loading: false,
+            loading: true,
             my_communities: []
         };
     }

--- a/ElastosBountyProgram/front-end/src/store/redux/user.js
+++ b/ElastosBountyProgram/front-end/src/store/redux/user.js
@@ -7,7 +7,7 @@ class UserRedux extends BaseRedux {
 
     defineDefaultState() {
         return {
-            loading: false,
+            loading: true,
 
             is_login: false,
             is_leader: false,


### PR DESCRIPTION
This is causing some serious problems - by firing something like update_detail or update_loading without scoping per redux type, we cause ALL the types having their store values updated. Particularly nasty when one wants more than 1 object's detail open at once at a page. Also was blocking proper loading state handling throughout the application.

Leveraged the new redux capability in loading states for all lists, which this PR introduces.