### PR TITLE
Allow persisting user login on a computer

### DIFF
--- a/ElastosBountyProgram/front-end/src/app.js
+++ b/ElastosBountyProgram/front-end/src/app.js
@@ -71,6 +71,7 @@ if (sessionStorage.getItem('api-token')) {
         },
         error: () => {
             sessionStorage.clear()
+            localStorage.removeItem('api-token')
             render()
         }
     });

--- a/ElastosBountyProgram/front-end/src/app.js
+++ b/ElastosBountyProgram/front-end/src/app.js
@@ -45,7 +45,11 @@ const render = () => {
     );
 };
 
-if(sessionStorage.getItem('api-token')){
+if (!sessionStorage.getItem('api-token') && localStorage.getItem('api-token')) {
+    sessionStorage.setItem('api-token', localStorage.getItem('api-token'))
+}
+
+if (sessionStorage.getItem('api-token')) {
     const userRedux = store.getRedux('user');
     api_request({
         path : '/api/user/current_user',

--- a/ElastosBountyProgram/front-end/src/module/form/LoginForm/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/form/LoginForm/Component.js
@@ -15,7 +15,7 @@ class C extends BaseComponent {
         this.props.form.validateFields((err, values) => {
             if (!err) {
                 console.log('Received values of form: ', values)
-                this.props.login(values.username, values.password, values.remember)
+                this.props.login(values.username, values.password, values.persist)
 
             }
         })
@@ -42,9 +42,15 @@ class C extends BaseComponent {
                 type="password" placeholder="Password"/>
         )
 
+        const persist_fn = getFieldDecorator('persist')
+        const persist_el = (
+            <Checkbox>Save on this computer</Checkbox>
+        )
+
         return {
             userName: userName_fn(userName_el),
-            pwd: pwd_fn(pwd_el)
+            pwd: pwd_fn(pwd_el),
+            persist: persist_fn(persist_el)
         }
     }
 
@@ -58,6 +64,9 @@ class C extends BaseComponent {
                 </FormItem>
                 <FormItem>
                     {p.pwd}
+                </FormItem>
+                <FormItem>
+                    {p.persist}
                 </FormItem>
                 <FormItem className="d_item">
                     <a className="login-form-forgot" href="">Forgot password</a>

--- a/ElastosBountyProgram/front-end/src/module/form/LoginForm/Container.js
+++ b/ElastosBountyProgram/front-end/src/module/form/LoginForm/Container.js
@@ -8,17 +8,17 @@ message.config({
 })
 
 
-export default createContainer(Component, (state)=>{
+export default createContainer(Component, (state) => {
     return {
         ...state.user.login_form
     }
-}, ()=>{
+}, () => {
     const userService = new UserService()
 
     return {
-        async login(username, password, profile){
+        async login(username, password, persist) {
             try {
-                const rs = await userService.login(username, password)
+                const rs = await userService.login(username, password, persist)
 
                 if (rs) {
                     message.success('login success')
@@ -33,6 +33,6 @@ export default createContainer(Component, (state)=>{
                 console.error(err)
                 message.error(err.message)
             }
-        },
+        }
     }
 })

--- a/ElastosBountyProgram/front-end/src/service/UserService.js
+++ b/ElastosBountyProgram/front-end/src/service/UserService.js
@@ -5,7 +5,7 @@ import {api_request} from '@/util';
 
 export default class extends BaseService {
 
-    async login(username, password, opts = {}) {
+    async login(username, password, persist) {
         const userRedux = this.store.getRedux('user')
 
         // call API /login
@@ -35,7 +35,12 @@ export default class extends BaseService {
         await this.dispatch(userRedux.actions.role_update(res.user.role))
         await this.dispatch(userRedux.actions.current_user_id_update(res.user._id))
         sessionStorage.setItem('api-token', res['api-token']);
-        localStorage.setItem('api-token', res['api-token']);
+
+        if (persist) {
+            localStorage.setItem('api-token', res['api-token'])
+        } else {
+            localStorage.removeItem('api-token')
+        }
 
         return {
             success: true,

--- a/ElastosBountyProgram/front-end/src/service/UserService.js
+++ b/ElastosBountyProgram/front-end/src/service/UserService.js
@@ -5,15 +5,14 @@ import {api_request} from '@/util';
 
 export default class extends BaseService {
 
-    async login(username, password, opts={}){
-
+    async login(username, password, opts = {}) {
         const userRedux = this.store.getRedux('user')
 
         // call API /login
         const res = await api_request({
-            path : '/api/user/login',
-            method : 'get',
-            data : {
+            path: '/api/user/login',
+            method: 'get',
+            data: {
                 username,
                 password
             }
@@ -36,6 +35,7 @@ export default class extends BaseService {
         await this.dispatch(userRedux.actions.role_update(res.user.role))
         await this.dispatch(userRedux.actions.current_user_id_update(res.user._id))
         sessionStorage.setItem('api-token', res['api-token']);
+        localStorage.setItem('api-token', res['api-token']);
 
         return {
             success: true,
@@ -130,15 +130,16 @@ export default class extends BaseService {
         return result
     }
 
-    async logout(){
+    async logout() {
         const userRedux = this.store.getRedux('user')
         const tasksRedux = this.store.getRedux('task')
 
-        return new Promise((resolve)=>{
+        return new Promise((resolve) => {
             this.dispatch(userRedux.actions.is_login_update(false))
             this.dispatch(userRedux.actions.profile_reset())
             this.dispatch(tasksRedux.actions.all_tasks_reset())
             sessionStorage.clear()
+            localStorage.removeItem('api-token', '')
             resolve(true)
         })
     }


### PR DESCRIPTION
1. During Login, it is possible to "save (login) on this computer".
2. During Login, api-token is saved in local storage if the option is selected, or removed from the local storage if not selected.
3. On authentication, if session storage does not contain saved token, local storage is checked and the saved token is used.
4. On logout, local storage gets cleared.