### PR TITLE
Fix: Clearing task detail state, Task detail not logged in view

### DIFF
--- a/ElastosBountyProgram/back-end/src/service/Base.ts
+++ b/ElastosBountyProgram/back-end/src/service/Base.ts
@@ -24,6 +24,10 @@ export default class Base {
     }
 
     protected async markLastSeenComment(commentable, createdBy, db_commentable) {
+        if (!this.currentUser) {
+            return
+        }
+
         if (commentable.comments && commentable.comments.length) {
             const subscriberInfo = _.find(commentable.subscribers, (subscriber) => {
                 return subscriber.user && subscriber.user._id.toString() === this.currentUser._id.toString()

--- a/ElastosBountyProgram/front-end/src/module/page/task_detail/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/task_detail/Component.js
@@ -19,11 +19,9 @@ export default class extends StandardPage {
         this.props.getTaskDetail(taskId)
     }
 
-    /*
     componentWillUnmount() {
         this.props.resetTaskDetail()
     }
-    */
 
     ord_renderContent () {
 


### PR DESCRIPTION
1. Clearing task detail state correctly after navigating away from public task view.
2. Task detail does not open when user if not logged in.