### PR TITLE
Semier/frontend/developer mobile responsive

### DIFF
--- a/ElastosBountyProgram/front-end/src/config/constant.js
+++ b/ElastosBountyProgram/front-end/src/config/constant.js
@@ -1,2 +1,5 @@
 export const RECAPTCHA_KEY = '6LeH0DIUAAAAAMfp3kJQdiW0y-4VsIM-y53GRBBD';
 export const MIN_LENGTH_PASSWORD = 8;
+
+export const MAX_WIDTH_MOBILE = 768;
+export const MIN_WIDTH_PC = 769;

--- a/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
@@ -167,7 +167,7 @@ export default class extends StandardPage {
                 </div>
                 <div className="ebp-page">
                     <Row className="d_row d_rowTop">
-                        <Col md={{span:24}} md={{span: 18}} className="d_leftContainer d_box">
+                        <Col sm={{span:24}} md={{span: 16}} className="d_leftContainer d_box">
                             <div className="pull-left btnContainer">
                                 <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.EVENT)}>
                                     Training
@@ -226,7 +226,7 @@ export default class extends StandardPage {
                             />
                             }
                         </Col>
-                        <Col md={{span:24}} md={{span: 6}} className="d_rightContainer d_box">
+                        <Col sm={{span:24}} md={{span: 8}} className="d_rightContainer d_box">
                             <h4>
                                 Submit an Issue
                             </h4>

--- a/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
@@ -179,15 +179,15 @@ export default class extends StandardPage {
                                     <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.TASK)}>
                                         Tasks
                                     </Button>
-                                </Col>
-                                <Col className="pull-right btnContainer">
                                     {this.props.currentUserId && this.props.is_admin &&
-                                    <Popover content={'add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'task' : 'project'))}>
+                                    <Popover content={'Add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'task' : 'project'))}>
                                         <Icon className="addTask" type="file-add" onClick={() => {
                                             this.props.history.push(`/task-create?category=DEVELOPER&type=${this.state.taskTypeSelected}`)
                                         }}/>
                                     </Popover>
                                     }
+                                </Col>
+                                <Col className="pull-right btnContainer">
                                     {filterCommunityEl}
                                     {/*
                                     // TODO

--- a/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
@@ -178,15 +178,15 @@ export default class extends StandardPage {
                                 <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.TASK)}>
                                     Tasks
                                 </Button>
-                            </div>
-                            <div className="pull-right btnContainer">
                                 {this.props.currentUserId && this.props.is_admin &&
-                                <Popover content={'add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'task' : 'project'))}>
+                                <Popover content={'Add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'task' : 'project'))}>
                                     <Icon className="addTask" type="file-add" onClick={() => {
                                         this.props.history.push(`/task-create?category=DEVELOPER&type=${this.state.taskTypeSelected}`)
                                     }}/>
                                 </Popover>
                                 }
+                            </div>
+                            <div className="pull-right btnContainer">
                                 {filterCommunityEl}
                                 {/*
                                 // TODO

--- a/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
@@ -168,34 +168,35 @@ export default class extends StandardPage {
                 <div className="ebp-page">
                     <Row className="d_row d_rowTop">
                         <Col sm={{span:24}} md={{span: 16}} className="d_leftContainer d_box">
-                            <div className="pull-left btnContainer">
-                                <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.EVENT)}>
-                                    Training
-                                </Button>
-                                <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.PROJECT ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.PROJECT)}>
-                                    Projects
-                                </Button>
-                                <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.TASK)}>
-                                    Tasks
-                                </Button>
-                                {this.props.currentUserId && this.props.is_admin &&
-                                <Popover content={'Add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'task' : 'project'))}>
-                                    <Icon className="addTask" type="file-add" onClick={() => {
-                                        this.props.history.push(`/task-create?category=DEVELOPER&type=${this.state.taskTypeSelected}`)
-                                    }}/>
-                                </Popover>
-                                }
-                            </div>
-                            <div className="pull-right btnContainer">
-                                {filterCommunityEl}
-                                {/*
-                                // TODO
-                                <Button onClick={this.createTaskLink.bind(this)}>
-                                    Suggest an Event
-                                </Button>
-                                */}
-                            </div>
-
+                            <Row type="flex" justify="space-between">
+                                <Col className="pull-left btnContainer">
+                                    <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.EVENT)}>
+                                        Training
+                                    </Button>
+                                    <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.PROJECT ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.PROJECT)}>
+                                        Projects
+                                    </Button>
+                                    <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.TASK)}>
+                                        Tasks
+                                    </Button>
+                                </Col>
+                                <Col className="pull-right btnContainer">
+                                    {this.props.currentUserId && this.props.is_admin &&
+                                    <Popover content={'add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'task' : 'project'))}>
+                                        <Icon className="addTask" type="file-add" onClick={() => {
+                                            this.props.history.push(`/task-create?category=DEVELOPER&type=${this.state.taskTypeSelected}`)
+                                        }}/>
+                                    </Popover>
+                                    }
+                                    {filterCommunityEl}
+                                    {/*
+                                    // TODO
+                                    <Button onClick={this.createTaskLink.bind(this)}>
+                                        Suggest an Event
+                                    </Button>
+                                    */}
+                                </Col>
+                            </Row>
                             <div className="vert-gap-sm clearfix"/>
 
                             {this.state.taskTypeSelected === TASK_TYPE.EVENT &&

--- a/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/Component.js
@@ -142,7 +142,7 @@ export default class extends StandardPage {
             className: 'right-align',
             render: (ela) => ela / 1000
         }, {
-            title: 'Register By',
+            title: 'Deadline',
             dataIndex: 'startTime',
             className: 'right-align',
             render: (startTime) => moment(startTime).format('MMM D')

--- a/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
@@ -37,7 +37,6 @@
   }
 
   table {
-
     > thead.ant-table-thead > tr > th {
       word-break: normal;
       white-space: nowrap;
@@ -45,12 +44,12 @@
 
     .ant-table-thead > tr > th {
       box-sizing: border-box;
-      @media only screen and (max-width: 720px) {
+      @media only screen and (max-width: $mobile-width) {
         padding: 0px;
       }
     }
     .ant-table-tbody > tr > td {
-      @media only screen and (max-width: 720px) {
+      @media only screen and (max-width: $mobile-width) {
         padding: 0px;
       }
     }

--- a/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
@@ -42,18 +42,6 @@
       white-space: nowrap;
     }
 
-    .ant-table-thead > tr > th {
-      box-sizing: border-box;
-      @media only screen and (max-width: $mobile-width) {
-        padding: 0px;
-      }
-    }
-    .ant-table-tbody > tr > td {
-      @media only screen and (max-width: $mobile-width) {
-        padding: 0px;
-      }
-    }
-
     td {
       word-break: normal;
 

--- a/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
@@ -10,9 +10,12 @@
   .d_box {
     padding: 0 $gap_3;
 
+    .pull-right {
+      text-align: right;
+    }
+
     .btnContainer {
       padding-top: $gap_1;
-      text-align: right;
 
       .ant-cascader-picker-label {
         text-align: left;

--- a/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
@@ -43,9 +43,20 @@
       white-space: nowrap;
     }
 
+    .ant-table-thead > tr > th {
+      box-sizing: border-box;
+      @media only screen and (max-width: 720px) {
+        padding: 0px;
+      }
+    }
+    .ant-table-tbody > tr > td {
+      @media only screen and (max-width: 720px) {
+        padding: 0px;
+      }
+    }
+
     td {
       word-break: normal;
-      white-space: nowrap;
 
       &.col-name {
         white-space: normal;

--- a/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
@@ -19,7 +19,8 @@
       }
 
       .addTask {
-        vertical-align: baseline;
+        vertical-align: middle;
+        padding: 0 20px;
         margin-right: $gap_0;
         font-size: 150%;
         cursor: pointer;

--- a/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/developer/style.scss
@@ -23,7 +23,6 @@
 
       .addTask {
         vertical-align: middle;
-        padding: 0 20px;
         margin-right: $gap_0;
         font-size: 150%;
         cursor: pointer;

--- a/ElastosBountyProgram/front-end/src/module/page/social/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Component.js
@@ -200,19 +200,19 @@ export default class extends StandardPage {
                                 <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.TASK)}>
                                     Tasks
                                 </Button>
-                                {this.props.currentUserId &&
-                                <Popover content={'Add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : 'task')}>
-                                    <Icon className="addTask" type="file-add" onClick={() => {
-                                        this.props.history.push(`/task-create?category=SOCIAL&type=${this.state.taskTypeSelected}`)
-                                    }}/>
-                                </Popover>
-                                }
                             </div>
                             <div className="pull-right btnContainer">
                                 {/*
                                 Looking for Help&nbsp;
                                 <Checkbox checked={this.state.lookingForHelpOnly}/>
                                 */}
+                                {this.props.currentUserId &&
+                                    <Popover content={'add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : 'task')}>
+                                        <Icon className="addTask" type="file-add" onClick={() => {
+                                            this.props.history.push(`/task-create?category=SOCIAL&type=${this.state.taskTypeSelected}`)
+                                        }}/>
+                                    </Popover>
+                                }
 
                                 {filterCommunityEl}
                                 {/*

--- a/ElastosBountyProgram/front-end/src/module/page/social/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Component.js
@@ -13,6 +13,7 @@ const Option = Select.Option
 
 import { SUBMISSION_TYPE, TASK_STATUS, TASK_TYPE } from '@/constant'
 import _ from 'lodash'
+import {MAX_WIDTH_MOBILE, MIN_WIDTH_PC} from "../../../config/constant";
 
 export default class extends StandardPage {
     state = {
@@ -222,7 +223,7 @@ export default class extends StandardPage {
                             </div>
                             <div class="vert-gap-sm clearfix"/>
 
-                            <MediaQuery minWidth={768}>
+                            <MediaQuery minWidth={MIN_WIDTH_PC}>
                                 {(matches) => {
                                     if (matches) {
                                         if(this.state.taskTypeSelected !== TASK_TYPE.EVENT)
@@ -253,7 +254,7 @@ export default class extends StandardPage {
                                     }
                                 }}
                             </MediaQuery>
-                            <MediaQuery maxWidth={768}>
+                            <MediaQuery maxWidth={MAX_WIDTH_MOBILE}>
                             {this.state.taskTypeSelected === TASK_TYPE.EVENT &&
                             <Table
                                 columns={columns}

--- a/ElastosBountyProgram/front-end/src/module/page/social/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Component.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import MediaQuery from "react-responsive"
 import StandardPage from '../StandardPage'
 import Footer from '@/module/layout/Footer/Container'
 import ContribForm from './formContribution/Container'
@@ -112,7 +113,7 @@ export default class extends StandardPage {
             render: (name, record) => {
                 return <a onClick={this.linkTaskDetail.bind(this, record._id)} className="tableLink">{name}</a>
             }
-        }, {
+        }, /*{
             title: 'Description',
             dataIndex: 'description',
             className: 'allow-wrap',
@@ -120,7 +121,7 @@ export default class extends StandardPage {
             render: (desc) => {
                 return _.truncate(desc, {length: 100})
             }
-        }, {
+        },*/ {
             title: 'Community',
             dataIndex: 'community',
             render: (community, data) => {
@@ -221,14 +222,48 @@ export default class extends StandardPage {
                             </div>
                             <div class="vert-gap-sm clearfix"/>
 
+                            <MediaQuery minWidth={768}>
+                                {(matches) => {
+                                    if (matches) {
+                                        if(this.state.taskTypeSelected !== TASK_TYPE.EVENT)
+                                        {
+                                            return null;
+                                        }
+                                        columns.splice(1, 0, {
+                                            title: 'Description',
+                                            dataIndex: 'description',
+                                            className: 'allow-wrap',
+                                            width: '30%',
+                                            render: (desc) => {
+                                                return _.truncate(desc, {length: 100})
+                                            }
+                                        })
+
+                                        return <Table
+                                            columns={columns}
+                                            rowKey={(item) => item._id}
+                                            dataSource={eventData}
+                                            loading={this.props.task_loading}
+                                        />;
+                                    } else {
+
+                                        var index = columns.findIndex(item => item.dataIndex === 'description');
+                                        columns.splice(index, 1);
+                                        return null;
+                                    }
+                                }}
+                            </MediaQuery>
+                            <MediaQuery maxWidth={768}>
                             {this.state.taskTypeSelected === TASK_TYPE.EVENT &&
                             <Table
                                 columns={columns}
                                 rowKey={(item) => item._id}
+                                expandedRowRender={record => <p style={{ margin: 0 }}>{record.description}</p>}
                                 dataSource={eventData}
                                 loading={this.props.task_loading}
                             />
                             }
+                            </MediaQuery>
                             {this.state.taskTypeSelected === TASK_TYPE.TASK &&
                             <Table
                                 className="clearfix"

--- a/ElastosBountyProgram/front-end/src/module/page/social/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Component.js
@@ -200,19 +200,19 @@ export default class extends StandardPage {
                                 <Button className={'pill ' + (this.state.taskTypeSelected === TASK_TYPE.TASK ? 'ant-btn-ebp' : '')} onClick={this.changeTaskType.bind(this, TASK_TYPE.TASK)}>
                                     Tasks
                                 </Button>
+                                {this.props.currentUserId &&
+                                <Popover content={'Add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : 'task')}>
+                                    <Icon className="addTask" type="file-add" onClick={() => {
+                                        this.props.history.push(`/task-create?category=SOCIAL&type=${this.state.taskTypeSelected}`)
+                                    }}/>
+                                </Popover>
+                                }
                             </div>
                             <div className="pull-right btnContainer">
                                 {/*
                                 Looking for Help&nbsp;
                                 <Checkbox checked={this.state.lookingForHelpOnly}/>
                                 */}
-                                {this.props.currentUserId &&
-                                    <Popover content={'add ' + (this.state.taskTypeSelected === TASK_TYPE.EVENT ? 'event' : 'task')}>
-                                        <Icon className="addTask" type="file-add" onClick={() => {
-                                            this.props.history.push(`/task-create?category=SOCIAL&type=${this.state.taskTypeSelected}`)
-                                        }}/>
-                                    </Popover>
-                                }
 
                                 {filterCommunityEl}
                                 {/*

--- a/ElastosBountyProgram/front-end/src/module/page/social/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/social/Component.js
@@ -144,7 +144,7 @@ export default class extends StandardPage {
             className: 'right-align',
             render: (ela) => ela / 1000
         }, {
-            title: 'Register By',
+            title: 'Deadline',
             dataIndex: 'startTime',
             className: 'right-align',
             render: (startTime) => moment(startTime).format('MMM D')
@@ -260,6 +260,7 @@ export default class extends StandardPage {
                                 columns={columns}
                                 rowKey={(item) => item._id}
                                 expandedRowRender={record => <p style={{ margin: 0 }}>{record.description}</p>}
+                                expandRowByClick={true}
                                 dataSource={eventData}
                                 loading={this.props.task_loading}
                             />

--- a/ElastosBountyProgram/front-end/src/module/page/social/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/social/style.scss
@@ -20,7 +20,6 @@
 
       .addTask {
         vertical-align: middle;
-        padding: 0 20px;
         margin-right: $gap_0;
         font-size: 150%;
         cursor: pointer;

--- a/ElastosBountyProgram/front-end/src/module/page/social/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/social/style.scss
@@ -32,8 +32,17 @@
     }
   }
 
-  .d_leftContainer {
-    border-right: 1px solid #e0e0e0;
+  .ebp-page {
+    .d_leftContainer {
+      border-right: none;
+    }
+    .d_rightContainer {
+      border-left: 1px solid #e0e0e0;
+
+      @media only screen and (max-width: $lg-width) {
+        border-left: none;
+      }
+    }
   }
 
   .d_socialEventsContainer {

--- a/ElastosBountyProgram/front-end/src/module/page/social/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/page/social/style.scss
@@ -19,7 +19,8 @@
       }
 
       .addTask {
-        vertical-align: baseline;
+        vertical-align: middle;
+        padding: 0 20px;
         margin-right: $gap_0;
         font-size: 150%;
         cursor: pointer;

--- a/ElastosBountyProgram/front-end/src/module/task/detail/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/task/detail/Component.js
@@ -55,7 +55,7 @@ export default class extends BaseComponent {
         return (
             <div className="public">
                 <Row>
-                    <Col span={18} className="gridCol main-area">
+                    <Col sm={24} md={18} className="gridCol main-area">
                         <Row>
                             <Col>
                                 <h4 className="center">
@@ -360,7 +360,7 @@ export default class extends BaseComponent {
                     * Applicants (Right Col)
                     ********************************************************************************
                     */}
-                    <Col span={6} className="gridCol applicants">
+                    <Col sm={24} md={6} className="gridCol applicants">
                         <h4>{this.state.isDeveloperEvent ? 'Registrants' : 'Applicants'}</h4>
 
                         {(this.props.task.candidates && this.props.task.candidates.length) ?

--- a/ElastosBountyProgram/front-end/src/module/task/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/task/style.scss
@@ -53,6 +53,12 @@
     .ant-row {
       margin: $gap_0 0;
 
+      div[class^="ant-col-"]{
+        @media only screen and (max-width: $mobile-width) {
+          float: none;
+        }
+      }
+
       p {
         padding-bottom: $gap_0;
       }
@@ -64,6 +70,12 @@
 
     .main-area {
       border-right: 1px solid $border_gray;
+
+      @media only screen and (max-width: $mobile-width) {
+        border-right: 0;
+        border-bottom: 1px solid $border_gray;
+        padding-bottom: 40px;
+      }
     }
 
     .applicants {

--- a/ElastosBountyProgram/front-end/src/module/task/style.scss
+++ b/ElastosBountyProgram/front-end/src/module/task/style.scss
@@ -80,11 +80,7 @@
 
     .applicants {
       text-align: center;
-
-      min-height: 40vh;
-
       position: relative;
-
       padding-bottom: $gap_3;
 
       .join-btn {

--- a/ElastosBountyProgram/front-end/src/style/antd.scss
+++ b/ElastosBountyProgram/front-end/src/style/antd.scss
@@ -112,3 +112,9 @@
   color: $cr_light_color;
   border-color: $cr_light_color;
 }
+
+.ant-table-pagination.ant-pagination {
+  max-width: fit-content;
+  margin: 16px auto;
+  float: none;
+}

--- a/ElastosBountyProgram/front-end/src/style/mobile.scss
+++ b/ElastosBountyProgram/front-end/src/style/mobile.scss
@@ -178,12 +178,11 @@
     padding: 0 $gap_1;
   }
 
-
   /*
   ****************************************************************************
   Other
   ****************************************************************************
-    */
+  */
   table {
     > thead.ant-table-thead > tr > th {
       word-break: normal;
@@ -191,15 +190,33 @@
     }
 
     .ant-table-thead > tr > th {
-      box-sizing: border-box;
-      @media only screen and (max-width: $mobile-width) {
-        padding: 3px;
-      }
+      padding: 3px 3px 20px;
     }
     .ant-table-tbody > tr > td {
-      @media only screen and (max-width: $mobile-width) {
-        padding: 3px;
+      padding: 3px;
+      font-size: 12px;
+    }
+  }
+
+  .p_Developer, .p_Social {
+
+    .d_box {
+      padding: 0;
+
+      .btnContainer {
+        float: left;
       }
     }
+
+    .ebp-page-desc > p {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+
+    .ant-table-expand-icon-th, .ant-table-row-expand-icon-cell {
+      min-width: min-content;
+      width: fit-content;
+    }
+
   }
 }

--- a/ElastosBountyProgram/front-end/src/style/mobile.scss
+++ b/ElastosBountyProgram/front-end/src/style/mobile.scss
@@ -6,7 +6,7 @@
 }
 
 // mobile
-@media only screen and (max-width: 720px) {
+@media only screen and (max-width: $mobile-width) {
 
   .mobile-hide {
     display: none;

--- a/ElastosBountyProgram/front-end/src/style/mobile.scss
+++ b/ElastosBountyProgram/front-end/src/style/mobile.scss
@@ -204,7 +204,15 @@
       padding: 0;
 
       .btnContainer {
-        float: left;
+        width: 100%;
+      }
+
+      .pull-left {
+        text-align: left;
+      }
+
+      .pull-right {
+        text-align: left;
       }
     }
 

--- a/ElastosBountyProgram/front-end/src/style/mobile.scss
+++ b/ElastosBountyProgram/front-end/src/style/mobile.scss
@@ -190,10 +190,10 @@
     }
 
     .ant-table-thead > tr > th {
-      padding: 3px 3px 20px;
+      padding: 16px 3px;
     }
     .ant-table-tbody > tr > td {
-      padding: 3px;
+      padding: 16px 3px;
       font-size: 12px;
     }
   }

--- a/ElastosBountyProgram/front-end/src/style/mobile.scss
+++ b/ElastosBountyProgram/front-end/src/style/mobile.scss
@@ -177,4 +177,29 @@
   .ant-form {
     padding: 0 $gap_1;
   }
+
+
+  /*
+  ****************************************************************************
+  Other
+  ****************************************************************************
+    */
+  table {
+    > thead.ant-table-thead > tr > th {
+      word-break: normal;
+      white-space: nowrap;
+    }
+
+    .ant-table-thead > tr > th {
+      box-sizing: border-box;
+      @media only screen and (max-width: $mobile-width) {
+        padding: 3px;
+      }
+    }
+    .ant-table-tbody > tr > td {
+      @media only screen and (max-width: $mobile-width) {
+        padding: 3px;
+      }
+    }
+  }
 }

--- a/ElastosBountyProgram/front-end/src/style/variable.scss
+++ b/ElastosBountyProgram/front-end/src/style/variable.scss
@@ -7,4 +7,4 @@ $gap_3: 40px;
 
 $header_height: 73px;
 
-$mobile-width: 750px;
+$mobile-width: 768px;

--- a/ElastosBountyProgram/front-end/src/style/variable.scss
+++ b/ElastosBountyProgram/front-end/src/style/variable.scss
@@ -6,3 +6,5 @@ $gap_2: 24px;
 $gap_3: 40px;
 
 $header_height: 73px;
+
+$mobile-width: 750px;

--- a/ElastosBountyProgram/front-end/src/style/variable.scss
+++ b/ElastosBountyProgram/front-end/src/style/variable.scss
@@ -8,3 +8,4 @@ $gap_3: 40px;
 $header_height: 73px;
 
 $mobile-width: 768px;
+$lg-width: 992px;


### PR DESCRIPTION
**Things to consider:**

**1**

AntDesign is using bootstrap grid breaking points:
https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints

So a <Col md={{span:16}} .. will break it at 768 pixels.
For a consistency I think we should use 768 for that mobile responsiveness change.

MAX_WIDTH_MOBILE = 768;
MIN_WIDTH_PC = 769;

**2**

I had trouble displaying all columns of the Events table. Right now, I made it so when you go below desktop width, the description column will be removed. The description from a row can be then shown by clicking on a row.

What do you think?