### PR TITLE
Automatically determine domain for cr100 projects when creating team

### DIFF
--- a/ElastosBountyProgram/front-end/src/module/page/project_detail/application/start/Component.js
+++ b/ElastosBountyProgram/front-end/src/module/page/project_detail/application/start/Component.js
@@ -52,6 +52,7 @@ class C extends BaseComponent {
                     })
                 } else if (this.state.mode === 'newteam') {
                     const sanitized = _.omit(values, [ 'team', 'applyMsg' ])
+                    sanitized.domain = this.props.task.domain
                     this.props.createTeam(sanitized).then((team) => {
                         this.props.applyToTask(this.props.task._id, null, team._id).then(() => {
                             this.setState({ confirmation: true })


### PR DESCRIPTION
Project Application CR100 -> Create Team -> You don't have to choose the domains/types. It will automatically determine from the chosen project.