### PR TITLE
Fix height cutoff of team description

### DIFF
--- a/ElastosBountyProgram/front-end/src/style/antd.scss
+++ b/ElastosBountyProgram/front-end/src/style/antd.scss
@@ -217,7 +217,7 @@ h3.one-line {
   }
 
   .ant-list-item-extra-wrap {
-    height: 188px;
+    height: 196px;
   }
 
   .ant-list-item-main {


### PR DESCRIPTION
Changed height of the container from 188px to 196px.
Since font size is 14px, 196px can be cleanly divided and displays descriptions without cutoffs.